### PR TITLE
Wrappers for [Initialize/Update]ProcThreadAttributeList & CreateProcess

### DIFF
--- a/DInvoke/DInvoke/DynamicInvoke/Win32.cs
+++ b/DInvoke/DInvoke/DynamicInvoke/Win32.cs
@@ -77,6 +77,74 @@ namespace DInvoke.DynamicInvoke
             return retVal;
         }
 
+        public static bool InitializeProcThreadAttributeList(IntPtr lpAttributeList, int dwAttributeCount, ref IntPtr lpSize)
+        {
+            object[] funcargs =
+            {
+                lpAttributeList,
+                dwAttributeCount,
+                0,
+                lpSize
+            };
+
+            bool retVal = (bool)Generic.DynamicAPIInvoke(@"kernel32.dll", @"InitializeProcThreadAttributeList", typeof(Delegates.InitializeProcThreadAttributeList), ref funcargs);
+
+            lpSize = (IntPtr)funcargs[3];
+            return retVal;
+        }
+
+        public static bool UpdateProcThreadAttribute(IntPtr lpAttributeList, IntPtr Attribute, IntPtr lpValue)
+        {
+            object[] funcargs =
+            {
+                lpAttributeList,
+                (uint)0,
+                Attribute,
+                lpValue,
+                (IntPtr)IntPtr.Size,
+                IntPtr.Zero,
+                IntPtr.Zero
+            };
+
+            bool retVal = (bool)Generic.DynamicAPIInvoke("kernel32.dll", "UpdateProcThreadAttribute", typeof(Delegates.UpdateProcThreadAttribute), ref funcargs);
+
+            return retVal;
+        }
+
+        public static bool CreateProcess(string lpApplicationName, string lpCommandLine, uint dwCreationFlags, string lpCurrentDirectory,
+            ref Data.Win32.ProcessThreadsAPI._STARTUPINFOEX lpStartupInfo, out Data.Win32.ProcessThreadsAPI._PROCESS_INFORMATION lpProcessInformation)
+        {
+            Data.Win32.WinBase._SECURITY_ATTRIBUTES lpProcessAttributes = new Data.Win32.WinBase._SECURITY_ATTRIBUTES();
+            Data.Win32.WinBase._SECURITY_ATTRIBUTES lpThreadAttributes = new Data.Win32.WinBase._SECURITY_ATTRIBUTES();
+            lpProcessAttributes.nLength = (uint)Marshal.SizeOf(lpProcessAttributes);
+            lpThreadAttributes.nLength = (uint)Marshal.SizeOf(lpThreadAttributes);
+
+            object[] funcargs =
+            {
+                lpApplicationName,
+                lpCommandLine,
+                lpProcessAttributes,
+                lpThreadAttributes,
+                false,
+                dwCreationFlags,
+                IntPtr.Zero,
+                lpCurrentDirectory,
+                lpStartupInfo,
+                null
+            };
+
+            bool retVal = (bool)Generic.DynamicAPIInvoke(
+                "kernel32.dll",
+                "CreateProcessA",
+                typeof(Delegates.CreateProcess),
+                ref funcargs,
+                true);
+
+            lpProcessInformation = (Data.Win32.ProcessThreadsAPI._PROCESS_INFORMATION)funcargs[9];
+
+            return retVal;
+        }
+
         public static class Delegates
         {
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -99,6 +167,36 @@ namespace DInvoke.DynamicInvoke
             public delegate bool IsWow64Process(
                 IntPtr hProcess, ref bool lpSystemInfo
             );
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool InitializeProcThreadAttributeList(
+                IntPtr lpAttributeList,
+                int dwAttributeCount,
+                int dwFlags,
+                ref IntPtr lpSize);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool UpdateProcThreadAttribute(
+                IntPtr lpAttributeList,
+                uint dwFlags,
+                IntPtr Attribute,
+                IntPtr lpValue,
+                IntPtr cbSize,
+                IntPtr lpPreviousValue,
+                IntPtr lpReturnSize);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool CreateProcess(
+                string lpApplicationName,
+                string lpCommandLine,
+                ref Data.Win32.WinBase._SECURITY_ATTRIBUTES lpProcessAttributes,
+                ref Data.Win32.WinBase._SECURITY_ATTRIBUTES lpThreadAttributes,
+                bool bInheritHandles,
+                uint dwCreationFlags,
+                IntPtr lpEnvironment,
+                string lpCurrentDirectory,
+                ref Data.Win32.ProcessThreadsAPI._STARTUPINFOEX lpStartupInfo,
+                out Data.Win32.ProcessThreadsAPI._PROCESS_INFORMATION lpProcessInformation);
         }
     }
 }

--- a/DInvoke/DInvoke/SharedData/Win32.cs
+++ b/DInvoke/DInvoke/SharedData/Win32.cs
@@ -542,9 +542,9 @@ namespace DInvoke.Data
             [StructLayout(LayoutKind.Sequential)]
             public struct _SECURITY_ATTRIBUTES
             {
-                UInt32 nLength;
-                IntPtr lpSecurityDescriptor;
-                Boolean bInheritHandle;
+                public UInt32 nLength;
+                public IntPtr lpSecurityDescriptor;
+                public Boolean bInheritHandle;
             };
         }
 
@@ -827,7 +827,7 @@ namespace DInvoke.Data
         public class ProcessThreadsAPI
         {
             [Flags]
-            internal enum STARTF : uint
+            public enum STARTF : uint
             {
                 STARTF_USESHOWWINDOW = 0x00000001,
                 STARTF_USESIZE = 0x00000002,
@@ -868,8 +868,8 @@ namespace DInvoke.Data
             [StructLayout(LayoutKind.Sequential)]
             public struct _STARTUPINFOEX
             {
-                _STARTUPINFO StartupInfo;
-                // PPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+                public _STARTUPINFO StartupInfo;
+                public IntPtr lpAttributeList;
             };
 
             //https://msdn.microsoft.com/en-us/library/windows/desktop/ms684873(v=vs.85).aspx


### PR DESCRIPTION
Initial draft for providing wrappers for `InitializeProcThreadAttributeList`, `InitializeProcThreadAttributeList` and `CreateProcess`.  `DeleteProcThreadAttributeList` to follow.

Feedback welcome - particularly interested in your option on issues like:
https://github.com/rasta-mouse/DInvoke/blob/dev/DInvoke/DInvoke/DynamicInvoke/Win32.cs#L117-L120

I've currently abstracted `SECURITY_ATTRIBUTES` away from the user, as I feel most use cases would not have a need to change them.  But should we not do that?  Should they be optional overloads?

Changes can be tested with the following:
```c#
using System;
using System.Diagnostics;
using System.Runtime.InteropServices;

using DInvoke.DynamicInvoke;
using Data = DInvoke.Data;

namespace TestApp
{
    class Program
    {
        static void Main(string[] args)
        {
            var si = new Data.Win32.ProcessThreadsAPI._STARTUPINFOEX();
            si.StartupInfo.cb = (uint)Marshal.SizeOf(si);
            si.StartupInfo.dwFlags = (uint)Data.Win32.ProcessThreadsAPI.STARTF.STARTF_USESHOWWINDOW;

            var lpValue = Marshal.AllocHGlobal(IntPtr.Size);

            var lpSize = IntPtr.Zero;

            var success = Win32.InitializeProcThreadAttributeList(
                IntPtr.Zero,
                2,
                ref lpSize);

            si.lpAttributeList = Marshal.AllocHGlobal(lpSize);

            success = Win32.InitializeProcThreadAttributeList(
                si.lpAttributeList,
                2,
                ref lpSize);

            if (Is64Bit)
            {
                Marshal.WriteIntPtr(lpValue, new IntPtr(0x100000000000));
            }
            else
            {
                Marshal.WriteIntPtr(lpValue, new IntPtr(unchecked((uint)0x100000000000)));
            }

            success = Win32.UpdateProcThreadAttribute(
                si.lpAttributeList,
                (IntPtr)0x20007,
                lpValue);

            var hParent = Process.GetProcessesByName("explorer")[0].Handle;
            lpValue = Marshal.AllocHGlobal(IntPtr.Size);
            Marshal.WriteIntPtr(lpValue, hParent);

            success = Win32.UpdateProcThreadAttribute(
                si.lpAttributeList,
                (IntPtr)0x00020000,
                lpValue);

            success = Win32.CreateProcess(
                null,
                "notepad",
                0x00080000,
                null,
                ref si,
                out Data.Win32.ProcessThreadsAPI._PROCESS_INFORMATION pi);
        }

        static bool Is64Bit
        {
            get
            {
                return IntPtr.Size == 8;
            }
        }
    }
}
```