### PR TITLE
wtsapi32 and NtQueryValueKey functions

### DIFF
--- a/DInvoke/DInvoke/DynamicInvoke/Native.cs
+++ b/DInvoke/DInvoke/DynamicInvoke/Native.cs
@@ -58,7 +58,7 @@ namespace DInvoke.DynamicInvoke
             // Craft an array for the arguments
             object[] funcargs =
             {
-                Process, ThreadSecurityDescriptor, CreateSuspended, ZeroBits, 
+                Process, ThreadSecurityDescriptor, CreateSuspended, ZeroBits,
                 MaximumStackSize, CommittedStackSize, StartAddress, Parameter,
                 Thread, ClientId
             };
@@ -95,8 +95,8 @@ namespace DInvoke.DynamicInvoke
             }
 
             // Update the modified variables
-            SectionHandle = (IntPtr) funcargs[0];
-            MaximumSize = (ulong) funcargs[3];
+            SectionHandle = (IntPtr)funcargs[0];
+            MaximumSize = (ulong)funcargs[3];
 
             return retValue;
         }
@@ -142,8 +142,8 @@ namespace DInvoke.DynamicInvoke
             }
 
             // Update the modified variables.
-            BaseAddress = (IntPtr) funcargs[2];
-            ViewSize = (ulong) funcargs[6];
+            BaseAddress = (IntPtr)funcargs[2];
+            ViewSize = (ulong)funcargs[6];
 
             return retValue;
         }
@@ -583,6 +583,55 @@ namespace DInvoke.DynamicInvoke
             return FileHandle;
         }
 
+        public static Data.Native.NTSTATUS NtOpenKey(
+            ref IntPtr keyHandle,
+            Data.Native.REG_ACCESS_MASK desiredAccess,
+            ref Data.Native.OBJECT_ATTRIBUTES objectAttributes)
+        {
+            object[] funcargs =
+            {
+                keyHandle,desiredAccess,objectAttributes
+            };
+            Data.Native.NTSTATUS retvalue = (Data.Native.NTSTATUS)Generic.DynamicAPIInvoke(@"ntdll.dll", @"NtOpenKey", typeof(DELEGATES.NtOpenKey), ref funcargs);
+            keyHandle = (IntPtr)funcargs[0];
+            return retvalue;
+        }
+
+        public static Data.Native.NTSTATUS NtQueryValueKey(
+            IntPtr keyHandle,
+            Data.Native.UNICODE_STRING UC_RegKeyValueName,
+            Data.Native.KEY_INFORMATION_CLASS KeyInformationClass,
+            ref IntPtr KeyInformation,
+            int DataSize,
+            ref int DataSizeResult)
+        {
+
+            object[] funcargs =
+            {
+                keyHandle,UC_RegKeyValueName,KeyInformationClass,KeyInformation,DataSize,DataSizeResult
+            };
+
+            Data.Native.NTSTATUS retvalue = (Data.Native.NTSTATUS)Generic.DynamicAPIInvoke(@"ntdll.dll", @"NtQueryValueKey", typeof(DELEGATES.NtQueryValueKey), ref funcargs);
+            KeyInformation = (IntPtr)funcargs[3];
+            DataSizeResult = (int)funcargs[5];
+
+            return retvalue;
+        }
+
+        public static void RtlMoveMemory(
+                byte[] Destination,
+                IntPtr Source,
+                int Length)
+        {
+            object[] funcargs =
+            {
+                Destination,Source,Length
+            };
+
+            Generic.DynamicAPIInvoke(@"ntdll.dll", @"RtlMoveMemory", typeof(DELEGATES.RtlMoveMemory), ref funcargs);
+        }
+
+
         /// <summary>
         /// Holds delegates for API calls in the NT Layer.
         /// Must be public so that they may be used with SharpSploit.Execution.DynamicInvoke.Generic.DynamicFunctionInvoke
@@ -782,6 +831,27 @@ namespace DInvoke.DynamicInvoke
                 ref Data.Native.IO_STATUS_BLOCK IoStatusBlock,
                 Data.Win32.Kernel32.FileShareFlags ShareAccess,
                 Data.Win32.Kernel32.FileOpenFlags OpenOptions);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate Data.Native.NTSTATUS NtOpenKey(
+              ref IntPtr keyHandle,
+              Data.Native.REG_ACCESS_MASK desiredAccess,
+              ref Data.Native.OBJECT_ATTRIBUTES objectAttributes);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate Data.Native.NTSTATUS NtQueryValueKey(
+            IntPtr keyHandle,
+            ref Data.Native.UNICODE_STRING valueName,
+            Data.Native.KEY_INFORMATION_CLASS KeyValueInformationClass,
+            IntPtr KeyValueInformation,
+            int DataSize,
+            ref int ResultSize);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate void RtlMoveMemory(
+                byte[] Destination,
+                IntPtr Source,
+                int Length);
         }
     }
 }

--- a/DInvoke/DInvoke/DynamicInvoke/Win32.cs
+++ b/DInvoke/DInvoke/DynamicInvoke/Win32.cs
@@ -77,8 +77,124 @@ namespace DInvoke.DynamicInvoke
             return retVal;
         }
 
+        /// <summary>
+        /// Uses DynamicInvocation to call the WTSOpenServerA Win32 API. https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsopenservera
+        /// </summary>
+        /// <returns>Returns a pointer to the local or remote session.</returns>
+        public static IntPtr WTSOpenServerA(string pServerName)
+        {
+
+            // Build the set of parameters to pass in to WTSOpenServerA
+            object[] funcargs =
+            {
+                pServerName
+            };
+
+            Generic.GetLibraryAddress(@"C:\Windows\System32\wtsapi32.dll", "WTSOpenServerA", true, true);
+            IntPtr hServer = (IntPtr)Generic.DynamicAPIInvoke(@"wtsapi32.dll", @"WTSOpenServerA", typeof(Delegates.WTSOpenServerA), ref funcargs);
+
+            return hServer;
+        }
+
+        /// <summary>
+        /// Uses DynamicInvocation to call the WTSEnumerateSessionsA Win32 API. https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsenumeratesessionsa
+        /// </summary>
+        /// <returns>Returns true or false after enumerating the sessions.</returns>
+        public static bool WTSEnumerateSessionsA(
+            IntPtr hServer,
+            int Reserved,
+            int Version,
+            ref IntPtr ppSessionInfo,
+            ref int pCount)
+        {
+
+            // Build the set of parameters to pass in to WTSEnumerateSessionsA
+            object[] funcargs =
+            {
+                IntPtr.Zero,0,1,ppSessionInfo,pCount
+            };
+
+            Generic.GetLibraryAddress(@"C:\Windows\System32\wtsapi32.dll", "WTSEnumerateSessionsA", true, true);
+            bool res = (bool)Generic.DynamicAPIInvoke(@"wtsapi32.dll", @"WTSEnumerateSessionsA", typeof(Delegates.WTSEnumerateSessionsA), ref funcargs);
+
+            ppSessionInfo = (IntPtr)funcargs[3];
+            pCount = (int)funcargs[4];
+
+            return res;
+        }
+
+        /// <summary>
+        /// Uses DynamicInvocation to call the WTSDisconnectSession Win32 API. https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-WTSDisconnectSession
+        /// </summary>
+        /// <returns>Returns true or false after disconnecting the target session.</returns>
+        public static bool WTSDisconnectSession(
+            IntPtr hServer, 
+            int SessionId, 
+            bool Wait)
+        {
+
+            // Build the set of parameters to pass in to WTSDisconnectSession
+            object[] funcargs =
+            {
+                hServer,SessionId,Wait
+            };
+
+            Generic.GetLibraryAddress(@"C:\Windows\System32\wtsapi32.dll", "WTSDisconnectSession", true, true);
+            bool res = (bool)Generic.DynamicAPIInvoke(@"wtsapi32.dll", @"WTSDisconnectSession", typeof(Delegates.WTSDisconnectSession), ref funcargs);
+
+            return res;
+        }
+
+        /// <summary>
+        /// Uses DynamicInvocation to call the WTSConnectSessionA Win32 API. https://docs.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-WTSConnectSessiona
+        /// </summary>
+        /// <returns>Returns true or false after opening the target session.</returns>
+        public static bool WTSConnectSession(
+            int TargetSessionId,
+            int SourceSessionId,
+            string Password,
+            bool Wait)
+        {
+
+            // Build the set of parameters to pass in to WTSConnectSessionA
+            object[] funcargs =
+            {
+                TargetSessionId,SourceSessionId,Password,Wait
+            };
+
+            Generic.GetLibraryAddress(@"C:\Windows\System32\wtsapi32.dll", "WTSConnectSessionA", true, true);
+            bool res = (bool)Generic.DynamicAPIInvoke(@"wtsapi32.dll", @"WTSConnectSessionA", typeof(Delegates.WTSConnectSession), ref funcargs);
+
+            return res;
+        }
+
         public static class Delegates
         {
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool WTSConnectSession(
+                    int targetSessionId,
+                    int sourceSessionId,
+                    string password,
+                    bool wait);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool WTSDisconnectSession(
+                IntPtr hServer,
+                int sessionId,
+                bool bWait);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate IntPtr WTSOpenServerA(
+                string pServerName);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool WTSEnumerateSessionsA(
+                IntPtr hServer,
+                int Reserved,
+                int Version,
+                ref IntPtr ppSessionInfo,
+                ref int pCount);
+
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
             public delegate IntPtr CreateRemoteThread(IntPtr hProcess,
                 IntPtr lpThreadAttributes,

--- a/DInvoke/DInvoke/SharedData/Native.cs
+++ b/DInvoke/DInvoke/SharedData/Native.cs
@@ -42,6 +42,51 @@ namespace DInvoke.Data
             }
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        public struct KEY_VALUE_BASIC_INFORMATION
+        {
+            public ulong TitleIndex;
+            public ulong Type;
+            public ulong NameLength;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 300)]
+            public string Name;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct KEY_VALUE_PARTIAL_INFORMATION
+        {
+            public long TitleIndex;
+            public long Type;
+            public ulong DataLength;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 300)]
+            public string Data;
+        }
+
+        public enum KEY_INFORMATION_CLASS
+        {
+            KeyBasicInformation = 0,
+            KeyFullInformation = 1,
+            KeyPartialInformation = 2,
+            KeyValueFullInformationAlign64 = 3,
+            KeyValuePartialInformationAlign64 = 4,
+            KeyValueLayerInformation = 5,
+            MaxKeyValueInfoClass = 6
+        }
+
+        [Flags]
+        public enum OBJ_ATTRIBUTES : uint
+        {
+
+            INHERIT = 0x00000002,
+            PERMANENT = 0x00000010,
+            EXCLUSIVE = 0x00000020,
+            CASE_INSENSITIVE = 0x00000040,
+            OPENIF = 0x00000080,
+            OPENLINK = 0x00000100,
+            KERNEL_HANDLE = 0x00000200,
+            FORCE_ACCESS_CHECK = 0x00000400,
+        };
+
         [StructLayout(LayoutKind.Sequential, Pack = 0)]
         public struct OBJECT_ATTRIBUTES
         {
@@ -522,6 +567,67 @@ namespace DInvoke.Data
             TransactionsNotFrozen = 0xc0190045,
 
             MaximumNtStatus = 0xffffffff
+        }
+
+        [Flags]
+        public enum REG_ACCESS_MASK : uint
+        {
+            DELETE = 0x00010000,
+            READ_CONTROL = 0x00020000,
+            WRITE_DAC = 0x00040000,
+            WRITE_OWNER = 0x00080000,
+            SYNCHRONIZE = 0x00100000,
+            STANDARD_RIGHTS_REQUIRED = 0x000F0000,
+            STANDARD_RIGHTS_READ = 0x00020000,
+            STANDARD_RIGHTS_WRITE = 0x00020000,
+            STANDARD_RIGHTS_EXECUTE = 0x00020000,
+            STANDARD_RIGHTS_ALL = 0x001F0000,
+            SPECIFIC_RIGHTS_ALL = 0x0000FFF,
+            ACCESS_SYSTEM_SECURITY = 0x01000000,
+            MAXIMUM_ALLOWED = 0x02000000,
+            GENERIC_READ = 0x80000000,
+            GENERIC_WRITE = 0x40000000,
+            GENERIC_EXECUTE = 0x20000000,
+            GENERIC_ALL = 0x10000000,
+            DESKTOP_READOBJECTS = 0x00000001,
+            DESKTOP_CREATEWINDOW = 0x00000002,
+            DESKTOP_CREATEMENU = 0x00000004,
+            DESKTOP_HOOKCONTROL = 0x00000008,
+            DESKTOP_JOURNALRECORD = 0x00000010,
+            DESKTOP_JOURNALPLAYBACK = 0x00000020,
+            DESKTOP_ENUMERATE = 0x00000040,
+            DESKTOP_WRITEOBJECTS = 0x00000080,
+            DESKTOP_SWITCHDESKTOP = 0x00000100,
+            WINSTA_ENUMDESKTOPS = 0x00000001,
+            WINSTA_READATTRIBUTES = 0x00000002,
+            WINSTA_ACCESSCLIPBOARD = 0x00000004,
+            WINSTA_CREATEDESKTOP = 0x00000008,
+            WINSTA_WRITEATTRIBUTES = 0x00000010,
+            WINSTA_ACCESSGLOBALATOMS = 0x00000020,
+            WINSTA_EXITWINDOWS = 0x00000040,
+            WINSTA_ENUMERATE = 0x00000100,
+            WINSTA_READSCREEN = 0x00000200,
+            WINSTA_ALL_ACCESS = 0x0000037F,
+
+            SECTION_ALL_ACCESS = 0x10000000,
+            SECTION_QUERY = 0x0001,
+            SECTION_MAP_WRITE = 0x0002,
+            SECTION_MAP_READ = 0x0004,
+            SECTION_MAP_EXECUTE = 0x0008,
+            SECTION_EXTEND_SIZE = 0x0010,
+
+            KEY_ALL_ACCESS = 0xF003F,
+            KEY_CREATE_LINK = 0x0020,
+            KEY_CREATE_SUB_KEY = 0x0004,
+            KEY_ENUMERATE_SUB_KEYS = 0x0008,
+            KEY_EXECUTE = 0x20019,
+            KEY_NOTIFY = 0x0010,
+            KEY_QUERY_VALUE = 0x0001,
+            KEY_READ = 0x20019,
+            KEY_SET_VALUE = 0x0002,
+            KEY_WOW64_32KEY = 0x0200,
+            KEY_WOW64_64KEY = 0x0100,
+            KEY_WRITE = 0x20006
         }
     }
 }

--- a/DInvoke/DInvoke/SharedData/Win32.cs
+++ b/DInvoke/DInvoke/SharedData/Win32.cs
@@ -15,6 +15,39 @@ namespace DInvoke.Data
     /// </remarks>
     public static class Win32
     {
+        public static class wtsapi32
+        {
+            [StructLayout(LayoutKind.Sequential)]
+            public struct WTS_SESSION_INFO
+            {
+                public int SessionId;
+                public IntPtr pWinStationName;
+                public WTS_CONNECTSTATE_CLASS State;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct WTS_PROCESS_INFO
+            {
+                public int SessionId;
+                public int ProcessId;
+                public string pProcessName;
+                public IntPtr pUserSid;
+            }
+
+            public enum WTS_CONNECTSTATE_CLASS
+            {
+                WTSActive,              // User logged on to WinStation
+                WTSConnected,           // WinStation connected to client
+                WTSConnectQuery,        // In the process of connecting to client
+                WTSShadow,              // Shadowing another WinStation
+                WTSDisconnected,        // WinStation logged on without client
+                WTSIdle,                // Waiting for client to connect
+                WTSListen,              // WinStation is listening for connection
+                WTSReset,               // WinStation is being reset
+                WTSDown,                // WinStation is down due to error
+                WTSInit,                // WinStation in initialization
+            }
+        }
         public static class Kernel32
         {
             public static uint MEM_COMMIT = 0x1000;


### PR DESCRIPTION
## Description
I have added some functions / delegates for **wtsapi32** (`WTSOpenServerA`, `WTSEnumerateSessionsA`, `WTSDisconnectSession`, `WTSConnectSession`) and **ntdll** (`RtlMoveMemory`, `NtQueryValueKey`). Hopefully I got the structure and the style properly, but all feedback is more than welcome because I would like to keep adding content. 

Any better approach when importing functions? (e.g., wtsapi32 - https://github.com/s0rtega/DInvoke/blob/90a6d54dbe9b58af2e6ca4eab3e2a275456b7685/DInvoke/DInvoke/DynamicInvoke/Win32.cs#L93)

## Test cases

### NtQueryValueKey / RtlMoveMemory

```
using System;
using System.Runtime.InteropServices;
using System.Security.Principal;
using System.Text;

namespace dinvoke_pr
{
    class Program
    {
        static object[] parseInformation(byte[] information)
        {
            byte[] titleIndexArr = new byte[4];
            byte[] typeArr = new byte[4];
            byte[] nameLenArr = new byte[4];
            Array.Copy(information, 0, titleIndexArr, 0, 4);
            Array.Copy(information, 4, typeArr, 0, 4);
            Array.Copy(information, 8, nameLenArr, 0, 4);

            int titleIndex = BitConverter.ToInt32(titleIndexArr, 0);
            int type = BitConverter.ToInt32(typeArr, 0);
            int nameLen = BitConverter.ToInt32(nameLenArr, 0);

            byte[] nameArr = new byte[nameLen];
            Array.Copy(information, 12, nameArr, 0, nameLen);
            string name = Encoding.Unicode.GetString(nameArr);

            Object[] result =
            {
                titleIndex,
                type,
                nameLen,
                name
            };

            return result;
        }

        static void Main(string[] args)
        {
            String sid = WindowsIdentity.GetCurrent().User.ToString();
            string hive = @"\Registry\User\" + sid;
            String regKey = hive + @"\Environment";
            IntPtr keyHandle = IntPtr.Zero;

            DInvoke.Data.Native.OBJECT_ATTRIBUTES oa = new DInvoke.Data.Native.OBJECT_ATTRIBUTES();
            DInvoke.Data.Native.UNICODE_STRING UC_RegKey = new DInvoke.Data.Native.UNICODE_STRING();
            DInvoke.DynamicInvoke.Native.RtlInitUnicodeString(ref UC_RegKey, regKey);

            IntPtr oaObjectName = Marshal.AllocHGlobal(Marshal.SizeOf(UC_RegKey));
            Marshal.StructureToPtr(UC_RegKey, oaObjectName, true);
            oa.Length = Marshal.SizeOf(oa);
            oa.Attributes = (uint)DInvoke.Data.Native.OBJ_ATTRIBUTES.CASE_INSENSITIVE;
            oa.ObjectName = oaObjectName;
            oa.SecurityDescriptor = IntPtr.Zero;
            oa.SecurityQualityOfService = IntPtr.Zero;
            DInvoke.Data.Native.NTSTATUS retValue = new DInvoke.Data.Native.NTSTATUS();

            retValue = DInvoke.DynamicInvoke.Native.NtOpenKey(ref keyHandle, DInvoke.Data.Native.REG_ACCESS_MASK.KEY_ALL_ACCESS, ref oa);

            string keyValueName = "Path";

            DInvoke.Data.Native.UNICODE_STRING UC_RegKeyValueName = new DInvoke.Data.Native.UNICODE_STRING();
            DInvoke.DynamicInvoke.Native.RtlInitUnicodeString(ref UC_RegKeyValueName, keyValueName);

            int regSize = 2048;
            IntPtr regBufferPointer = Marshal.AllocHGlobal(regSize);
            int nLength = 0;

            retValue = DInvoke.DynamicInvoke.Native.NtQueryValueKey(keyHandle, UC_RegKeyValueName, DInvoke.Data.Native.KEY_INFORMATION_CLASS.KeyPartialInformation,
                                                                       ref regBufferPointer, regSize, ref nLength);

            if (retValue != DInvoke.Data.Native.NTSTATUS.ObjectNameNotFound)
            {
                byte[] baTemp = new byte[nLength];
                DInvoke.DynamicInvoke.Native.RtlMoveMemory(baTemp, regBufferPointer, nLength);
                object[] hkeyRegBasicInfo = parseInformation(baTemp);

                Console.WriteLine((string)hkeyRegBasicInfo[3]);
            }
        }
    }
}
```

### WTS*

```
using System;
using System.Runtime.InteropServices;

namespace dinvoke_pr
{
    class Program
    {
        static void Main(string[] args)
        {
            int target_session = 3;
            string serverName = "localhost";
            IntPtr hServer = DInvoke.DynamicInvoke.Win32.WTSOpenServerA(serverName);
            
            IntPtr pSessions = IntPtr.Zero;
            int dwSessionCount = 0;
            int activeSession = 0;

            bool res = DInvoke.DynamicInvoke.Win32.WTSEnumerateSessionsA(IntPtr.Zero, 0,1, ref pSessions, ref dwSessionCount);

            IntPtr current = pSessions;
            for (int i = 0; i < dwSessionCount; ++i)
            {
                DInvoke.Data.Win32.wtsapi32.WTS_SESSION_INFO session_info = (DInvoke.Data.Win32.wtsapi32.WTS_SESSION_INFO)Marshal.PtrToStructure(current, 
                                                                                    typeof(DInvoke.Data.Win32.wtsapi32.WTS_SESSION_INFO));
                if (session_info.State == DInvoke.Data.Win32.wtsapi32.WTS_CONNECTSTATE_CLASS.WTSActive)
                    activeSession = session_info.SessionId;
                // Only available in .net +4.0
                current += Marshal.SizeOf(typeof(DInvoke.Data.Win32.wtsapi32.WTS_SESSION_INFO));
            }

            // requires SYSTEM
            res = DInvoke.DynamicInvoke.Win32.WTSDisconnectSession(IntPtr.Zero, target_session, false);
            res = DInvoke.DynamicInvoke.Win32.WTSConnectSession(target_session, activeSession, "", false);
        }
    }
}
```