### PR TITLE
New options added to CallMappedDLLModuleExport

### DIFF
--- a/DInvoke/DInvoke/DynamicInvoke/Generic.cs
+++ b/DInvoke/DInvoke/DynamicInvoke/Generic.cs
@@ -256,7 +256,7 @@ namespace DInvoke.DynamicInvoke
         /// <param name="ExportName">The name of the export to search for (e.g. "NtAlertResumeThread").</param>
         /// <param name="ResolveForwards">Whether or not to resolve export forwards. Default is true.</param>
         /// <returns>IntPtr for the desired function.</returns>
-        public static IntPtr GetExportAddress(IntPtr ModuleBase, string ExportName, bool ResolveForwards = true)
+        public static IntPtr GetExportAddress(IntPtr ModuleBase, string ExportName, bool ResolveForwards = true, bool CanLoadFromDisk = false, bool Overload = false)
         {
             IntPtr FunctionPtr = IntPtr.Zero;
             try
@@ -303,7 +303,7 @@ namespace DInvoke.DynamicInvoke
                         
                         if (ResolveForwards == true)
                             // If the export address points to a forward, get the address
-                            FunctionPtr = GetForwardAddress(FunctionPtr);
+                            FunctionPtr = GetForwardAddress(FunctionPtr, CanLoadFromDisk, Overload);
 
                         break;
                     }
@@ -331,7 +331,7 @@ namespace DInvoke.DynamicInvoke
         /// <param name="Ordinal">The ordinal number to search for (e.g. 0x136 -> ntdll!NtCreateThreadEx).</param>
         /// <param name="ResolveForwards">Whether or not to resolve export forwards. Default is true.</param>
         /// <returns>IntPtr for the desired function.</returns>
-        public static IntPtr GetExportAddress(IntPtr ModuleBase, short Ordinal, bool ResolveForwards = true)
+        public static IntPtr GetExportAddress(IntPtr ModuleBase, short Ordinal, bool ResolveForwards = true, bool CanLoadFromDisk = false, bool Overload = false)
         {
             IntPtr FunctionPtr = IntPtr.Zero;
             try
@@ -400,7 +400,7 @@ namespace DInvoke.DynamicInvoke
         /// <param name="Key">64-bit integer to initialize the keyed hash object (e.g. 0xabc or 0x1122334455667788).</param>
         /// <param name="ResolveForwards">Whether or not to resolve export forwards. Default is true.</param>
         /// <returns>IntPtr for the desired function.</returns>
-        public static IntPtr GetExportAddress(IntPtr ModuleBase, string FunctionHash, long Key, bool ResolveForwards = true)
+        public static IntPtr GetExportAddress(IntPtr ModuleBase, string FunctionHash, long Key, bool ResolveForwards = true, bool CanLoadFromDisk = false, bool Overload = false)
         {
             IntPtr FunctionPtr = IntPtr.Zero;
             try
@@ -467,8 +467,9 @@ namespace DInvoke.DynamicInvoke
         /// <author>The Wover (@TheRealWover)</author>
         /// <param name="ExportAddress">Function of an exported address, found by parsing a PE file's export table.</param>
         /// <param name="CanLoadFromDisk">Optional, indicates if the function can try to load the DLL from disk if it is not found in the loaded module list.</param>
+        /// <param name="Overload">Optional, indicates if the dll should be loaded using overload</param>
         /// <returns>IntPtr for the forward. If the function is not forwarded, return the original pointer.</returns>
-        public static IntPtr GetForwardAddress(IntPtr ExportAddress, bool CanLoadFromDisk = false)
+        public static IntPtr GetForwardAddress(IntPtr ExportAddress, bool CanLoadFromDisk = false, bool Overload = false)
         {
             IntPtr FunctionPtr = ExportAddress;
             try
@@ -492,7 +493,15 @@ namespace DInvoke.DynamicInvoke
 
                     IntPtr hModule = GetPebLdrModuleEntry(ForwardModuleName);
                     if (hModule == IntPtr.Zero && CanLoadFromDisk == true)
-                        hModule = LoadModuleFromDisk(ForwardModuleName);
+                        if (Overload)
+                        {
+                            StringBuilder ForwardModulePath = new StringBuilder("",256);
+                            IntPtr ForwardModulePathOut;
+                            Data.Native.NTSTATUS res = Win32.SearchPathW(null, ForwardModuleName, null, (UInt32)ForwardModulePath.Capacity, ForwardModulePath, out ForwardModulePathOut);
+                            hModule = ManualMap.Overload.OverloadModule(ForwardModulePath.ToString()).ModuleBase;
+                        }
+                        else
+                            hModule = LoadModuleFromDisk(ForwardModuleName);
                     if (hModule != IntPtr.Zero)
                     {
                         FunctionPtr = GetExportAddress(hModule, ForwardExportName);
@@ -716,8 +725,10 @@ namespace DInvoke.DynamicInvoke
         /// <param name="FunctionDelegateType">Prototype for the function, represented as a Delegate object.</param>
         /// <param name="Parameters">Arbitrary set of parameters to pass to the function. Can be modified if function uses call by reference.</param>
         /// <param name="CallEntry">Specify whether to invoke the module's entry point.</param>
+        /// <param name="CanLoadFromDisk">Optional, indicates if the function can try to load the DLL from disk if it is not found in the loaded module list.</param>
+        /// <param name="Overload">Optional, indicates if the dll should be loaded using overload</param>
         /// <returns>void</returns>
-        public static object CallMappedDLLModuleExport(Data.PE.PE_META_DATA PEINFO, IntPtr ModuleMemoryBase, string ExportName, Type FunctionDelegateType, object[] Parameters, bool CallEntry = true)
+        public static object CallMappedDLLModuleExport(Data.PE.PE_META_DATA PEINFO, IntPtr ModuleMemoryBase, string ExportName, Type FunctionDelegateType, object[] Parameters, bool CallEntry = true, bool CanLoadFromDisk = false, bool Overload = false)
         {
             // Call entry point if user has specified
             if (CallEntry)
@@ -726,7 +737,7 @@ namespace DInvoke.DynamicInvoke
             }
 
             // Get export pointer
-            IntPtr pFunc = GetExportAddress(ModuleMemoryBase, ExportName);
+            IntPtr pFunc = GetExportAddress(ModuleMemoryBase, ExportName, CanLoadFromDisk: CanLoadFromDisk, Overload: Overload);
 
             // Call export
             return DynamicFunctionInvoke(pFunc, FunctionDelegateType, ref Parameters);
@@ -742,8 +753,10 @@ namespace DInvoke.DynamicInvoke
         /// <param name="FunctionDelegateType">Prototype for the function, represented as a Delegate object.</param>
         /// <param name="Parameters">Arbitrary set of parameters to pass to the function. Can be modified if function uses call by reference.</param>
         /// <param name="CallEntry">Specify whether to invoke the module's entry point.</param>
+        /// <param name="CanLoadFromDisk">Optional, indicates if the function can try to load the DLL from disk if it is not found in the loaded module list.</param>
+        /// <param name="Overload">Optional, indicates if the dll should be loaded using overload</param>
         /// <returns>void</returns>
-        public static object CallMappedDLLModuleExport(Data.PE.PE_META_DATA PEINFO, IntPtr ModuleMemoryBase, short Ordinal, Type FunctionDelegateType, object[] Parameters, bool CallEntry = true)
+        public static object CallMappedDLLModuleExport(Data.PE.PE_META_DATA PEINFO, IntPtr ModuleMemoryBase, short Ordinal, Type FunctionDelegateType, object[] Parameters, bool CallEntry = true, bool CanLoadFromDisk = false, bool Overload = false)
         {
             // Call entry point if user has specified
             if (CallEntry)
@@ -752,7 +765,7 @@ namespace DInvoke.DynamicInvoke
             }
 
             // Get export pointer
-            IntPtr pFunc = GetExportAddress(ModuleMemoryBase, Ordinal);
+            IntPtr pFunc = GetExportAddress(ModuleMemoryBase, Ordinal, CanLoadFromDisk: CanLoadFromDisk, Overload: Overload);
 
             // Call export
             return DynamicFunctionInvoke(pFunc, FunctionDelegateType, ref Parameters);
@@ -769,8 +782,10 @@ namespace DInvoke.DynamicInvoke
         /// <param name="FunctionDelegateType">Prototype for the function, represented as a Delegate object.</param>
         /// <param name="Parameters">Arbitrary set of parameters to pass to the function. Can be modified if function uses call by reference.</param>
         /// <param name="CallEntry">Specify whether to invoke the module's entry point.</param>
+        /// <param name="CanLoadFromDisk">Optional, indicates if the function can try to load the DLL from disk if it is not found in the loaded module list.</param>
+        /// <param name="Overload">Optional, indicates if the dll should be loaded using overload</param>
         /// <returns>void</returns>
-        public static object CallMappedDLLModuleExport(Data.PE.PE_META_DATA PEINFO, IntPtr ModuleMemoryBase, string FunctionHash, long Key, Type FunctionDelegateType, object[] Parameters, bool CallEntry = true)
+        public static object CallMappedDLLModuleExport(Data.PE.PE_META_DATA PEINFO, IntPtr ModuleMemoryBase, string FunctionHash, long Key, Type FunctionDelegateType, object[] Parameters, bool CallEntry = true, bool CanLoadFromDisk = false, bool Overload = false)
         {
             // Call entry point if user has specified
             if (CallEntry)
@@ -779,7 +794,7 @@ namespace DInvoke.DynamicInvoke
             }
 
             // Get export pointer
-            IntPtr pFunc = GetExportAddress(ModuleMemoryBase, FunctionHash, Key);
+            IntPtr pFunc = GetExportAddress(ModuleMemoryBase, FunctionHash, Key, CanLoadFromDisk: CanLoadFromDisk, Overload: Overload);
 
             // Call export
             return DynamicFunctionInvoke(pFunc, FunctionDelegateType, ref Parameters);

--- a/DInvoke/DInvoke/DynamicInvoke/Win32.cs
+++ b/DInvoke/DInvoke/DynamicInvoke/Win32.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace DInvoke.DynamicInvoke
 {
@@ -56,6 +57,29 @@ namespace DInvoke.DynamicInvoke
             return retValue;
         }
 
+        public static Data.Native.NTSTATUS SearchPathW(
+                string lpPath,
+                string lpFileName,
+                string lpExtension,
+                UInt32 nBufferLength,
+                StringBuilder lpBuffer,
+                out IntPtr filePartOut)
+        {
+            filePartOut = IntPtr.Zero;
+            // Craft an array for the arguments
+            object[] funcargs =
+            {
+                lpPath, lpFileName, lpExtension, nBufferLength, lpBuffer, filePartOut
+            };
+
+            Data.Native.NTSTATUS retValue = (Data.Native.NTSTATUS)Generic.DynamicAPIInvoke(@"kernel32.dll", @"SearchPathW", typeof(Delegates.SearchPathW), ref funcargs);
+
+            // Update the modified variables
+            filePartOut = (IntPtr)funcargs[5];
+
+            return retValue;
+        }
+
         /// <summary>
         /// Uses DynamicInvocation to call the IsWow64Process Win32 API. https://docs.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process
         /// </summary>
@@ -66,7 +90,7 @@ namespace DInvoke.DynamicInvoke
             // Build the set of parameters to pass in to IsWow64Process
             object[] funcargs =
             {
-                hProcess, lpSystemInfo
+                hProcess,lpSystemInfo
             };
 
             bool retVal = (bool)Generic.DynamicAPIInvoke(@"kernel32.dll", @"IsWow64Process", typeof(Delegates.IsWow64Process), ref funcargs);
@@ -79,8 +103,23 @@ namespace DInvoke.DynamicInvoke
 
         public static class Delegates
         {
+            // https://github.com/Tarkiyah/ansible/blob/b0c8e7926f4ed31c37fabfad7803bd378f8aaba4/lib/ansible/module_utils/csharp/Ansible.Process.cs
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-            public delegate IntPtr CreateRemoteThread(IntPtr hProcess,
+            public delegate Data.Native.NTSTATUS SearchPathW(
+                [MarshalAs(UnmanagedType.LPWStr)] 
+                string lpPath,
+                [MarshalAs(UnmanagedType.LPWStr)] 
+                string lpFileName,
+                [MarshalAs(UnmanagedType.LPWStr)] 
+                string lpExtension,
+                UInt32 nBufferLength,
+                [MarshalAs(UnmanagedType.LPTStr)]
+                StringBuilder lpBuffer,
+                ref IntPtr lpFilePart);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate IntPtr CreateRemoteThread(
+                IntPtr hProcess,
                 IntPtr lpThreadAttributes,
                 uint dwStackSize,
                 IntPtr lpStartAddress,


### PR DESCRIPTION
## Description

Based on the changes addressing the Issue #17 I added two additional options (CanLoadFromDisk, Overload) to CallMappedDLLModuleExport and GetExportAddress. Using these flags when a module is forwarded (e.g., SAMCLI.dll) it is possible to control if the module will be loaded from disk and how it will be loaded (direct / overload).

I am not 100% sure if this make sense, because is also increasing the complexity of the code, but can be handy under certain scenarios. If I am trying to overload the parent module does not make sense to end loading the forwarded one which could be even more suspicious. Happy to discuss is there is a better approach (or if that even makes sense).

## Test code

I did some "regression" testing with some of the DInvoke examples and DInvisibleRegistry (https://github.com/NVISO-BE/DInvisibleRegistry) everything seems to work OK.
To check the new flags, there is a quick example reusing the same:

```
using System;
using System.Runtime.InteropServices;

namespace overload_poc
{
    class STRUCTS
    {
        [StructLayout(LayoutKind.Sequential)]
        public struct LOCALGROUP_MEMBERS_INFO_3
        {
            [MarshalAs(UnmanagedType.LPWStr)]
            public string domainandname;
        }
    }

    class DELEGATES
    {
        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
        public delegate DInvoke.Data.Native.NTSTATUS NetLocalGroupAddMembers(
            string servername,
            [MarshalAs(UnmanagedType.LPWStr)]
            string groupName,
            UInt32 level,
            ref STRUCTS.LOCALGROUP_MEMBERS_INFO_3 info,
            UInt32 totalentries);
    }
    class Program
    {
        static void Main(string[] args)
        {

            // NetLocalGroupAddMember (forwarded to SAMCLI.NetLocalGroupAddMember)
            DInvoke.Data.PE.PE_MANUAL_MAP mappedDLL = DInvoke.ManualMap.Overload.OverloadModule(@"C:\Windows\System32\netapi32.dll", @"C:\Windows\System32\netapi32.dll");


            String group = @"Administrators";
            STRUCTS.LOCALGROUP_MEMBERS_INFO_3 username = new STRUCTS.LOCALGROUP_MEMBERS_INFO_3();
            username.domainandname = @"myUser";

            object[] funcParams =
                {
                    null,
                    group,
                    (UInt32)3,
                    username,
                    (UInt32)1};

            
            DInvoke.Data.Native.NTSTATUS res = (DInvoke.Data.Native.NTSTATUS)DInvoke.DynamicInvoke.Generic.CallMappedDLLModuleExport(
                                        mappedDLL.PEINFO,
                                        mappedDLL.ModuleBase,
                                        "NetLocalGroupAddMembers",
                                        typeof(DELEGATES.NetLocalGroupAddMembers),
                                        funcParams,
                                        false,
                                        true,
                                        false
                                        );

            Console.WriteLine(res);
        }
    }
} 
```

