### PR TITLE
Fix module lookup

### DIFF
--- a/DInvoke/DInvoke/DynamicInvoke/Generic.cs
+++ b/DInvoke/DInvoke/DynamicInvoke/Generic.cs
@@ -164,7 +164,7 @@ namespace DInvoke.DynamicInvoke
             ProcessModuleCollection ProcModules = Process.GetCurrentProcess().Modules;
             foreach (ProcessModule Mod in ProcModules)
             {
-                if (Mod.FileName.ToLower().EndsWith(DLLName.ToLower()))
+                if (Mod.FileName.ToLower().EndsWith("\\" + DLLName.ToLower()))
                 {
                     return Mod.BaseAddress;
                 }


### PR DESCRIPTION
The GetLoadedModuleAddress incorrectly matches some modules e.g. msi.dll matches amsi.dll 